### PR TITLE
feat: add config for automated version discussion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
           draft: ${{ contains(github.ref_name, 'draft') }}
           prerelease: ${{ !contains(github.ref_name, 'draft') && (contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc')) }}
           generate_release_notes: true
+          discussion_category_name: Versions
           files: |
             ${{ env.ASSET_FILE_NAME_NO_EXT }}.mrpack
             ${{ env.ASSET_FILE_NAME_NO_EXT }}_attestation.zip

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ This modpack uses [`packwiz`][packwiz] to manage and export the files.
 4. Make manual changes, if necessary (e.g. set the `preserve` flag in `index.toml`)
 5. Run the [release script](./scripts/release.py)
    - The `<new_version>` argument will be used as Git tag
-6. Optional for local import: Run the [env change script](./scripts/client-env-required.py)
+6. Add information to the [version discussion](https://github.com/scyfar/scydventure/discussions/categories/versions)
+   on GitHub
+7. Optional for local import: Run the [env change script](./scripts/client-env-required.py)
 
 The `release.py` script is called with the `<new_version>` as only argument:
 


### PR DESCRIPTION
Every release now should get a version discussion to discuss this version specifically.

Unfortunately, the initial post content can not be provided.

Closes: #14