### PR TITLE
feat: add a singleplayer artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 env:
   ASSET_FILE_NAME_NO_EXT: "Scydventure-${{ github.ref_name }}"
+  ASSET_FILE_SINGLEPLAYER_SUFFIX: "_singleplayer"
+  ASSET_FILE_ATTESTATION_SUFFIX: "_attestation"
 
 jobs:
   build:
@@ -30,22 +32,27 @@ jobs:
       - name: install packwiz
         run: go install github.com/packwiz/packwiz@latest
       - name: build artifact
-        run: python ./scripts/_export-mrpack.py "${{ github.ref_name }}" ${{ env.ASSET_FILE_NAME_NO_EXT }}.mrpack
+        run: python ./scripts/_export-mrpack.py "${{ github.ref_name }}" "${{ env.ASSET_FILE_NAME_NO_EXT }}.mrpack"
+      - name: build singleplayer artifact
+        run: python ./scripts/_client-env-required.py "${{ env.ASSET_FILE_NAME_NO_EXT }}.mrpack" "${{ env.ASSET_FILE_NAME_NO_EXT }}${{ env.ASSET_FILE_SINGLEPLAYER_SUFFIX }}.mrpack"
       - name: attest build provenance
         id: attest
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: ${{ env.ASSET_FILE_NAME_NO_EXT }}.mrpack
+          subject-path: |-
+            ${{ env.ASSET_FILE_NAME_NO_EXT }}.mrpack
+            ${{ env.ASSET_FILE_NAME_NO_EXT }}${{ env.ASSET_FILE_SINGLEPLAYER_SUFFIX }}.mrpack
       - name: zip attestation
         run: |-
-          zip ${{ env.ASSET_FILE_NAME_NO_EXT }}_attestation.zip ${{ steps.attest.outputs.bundle-path }}
+          zip ${{ env.ASSET_FILE_NAME_NO_EXT }}${{ env.ASSET_FILE_ATTESTATION_SUFFIX }}.zip ${{ steps.attest.outputs.bundle-path }}
       - name: upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: release-files
           path: |-
             ${{ env.ASSET_FILE_NAME_NO_EXT }}.mrpack
-            ${{ env.ASSET_FILE_NAME_NO_EXT }}_attestation.zip
+            ${{ env.ASSET_FILE_NAME_NO_EXT }}${{ env.ASSET_FILE_SINGLEPLAYER_SUFFIX }}.mrpack
+            ${{ env.ASSET_FILE_NAME_NO_EXT }}${{ env.ASSET_FILE_ATTESTATION_SUFFIX }}.zip
   release:
     runs-on: ubuntu-latest
     needs: build
@@ -63,7 +70,8 @@ jobs:
           discussion_category_name: Versions
           files: |-
             ${{ env.ASSET_FILE_NAME_NO_EXT }}.mrpack
-            ${{ env.ASSET_FILE_NAME_NO_EXT }}_attestation.zip
+            ${{ env.ASSET_FILE_NAME_NO_EXT }}${{ env.ASSET_FILE_SINGLEPLAYER_SUFFIX }}.mrpack
+            ${{ env.ASSET_FILE_NAME_NO_EXT }}${{ env.ASSET_FILE_ATTESTATION_SUFFIX }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
   publish:
@@ -125,7 +133,8 @@ jobs:
             ${{ steps.extract.outputs.mc_version }}
           files: |-
             ${{ env.ASSET_FILE_NAME_NO_EXT }}.mrpack
-            ${{ env.ASSET_FILE_NAME_NO_EXT }}_attestation.zip
+            ${{ env.ASSET_FILE_NAME_NO_EXT }}${{ env.ASSET_FILE_SINGLEPLAYER_SUFFIX }}.mrpack
+            ${{ env.ASSET_FILE_NAME_NO_EXT }}${{ ASSET_FILE_ATTESTATION_SUFFIX }}.zip
           primary-file: ${{ env.ASSET_FILE_NAME_NO_EXT }}.mrpack
           dependencies: |-
             [{"project_id": "HVnmMxH1", "dependency_type": "optional"}]

--- a/scripts/_client-env-required.py
+++ b/scripts/_client-env-required.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+import json
+import os
+import shutil
+import sys
+import tempfile
+import zipfile
+
+#! Force the client side config to `required` in the `mrpack`.
+#!
+#! # Usage
+#! ```
+#! python client-env-required.py `<source_file>` `<target_file>`
+#! ```
+#!
+#! # Description
+#! The required `<source_file>` must point to the input `mrpack` file.
+#! The required `<target_file>` will be the repacked `mrpack` file.
+#!
+#! The `<source_file>` will be repacked with the client config set to `required` for all mods.
+#!
+#! Unpacks the `<source_file>` in a local `tmp` directory.
+#!
+#! # References
+#! - https://github.com/scyfar/scydventure/discussions/25#discussion-8087151
+#! - https://github.com/modrinth/code/blob/827e3ec0a0a7149709df4d292add222c490e8318/packages/app-lib/src/api/profile/mod.rs#L860C1-L865C65
+
+# Verify required arguments
+if len(sys.argv) < 3:
+    print(f"Usage: python {os.path.basename(__file__)} <source_file> <target_file>")
+    sys.exit(1)
+
+source_file = os.path.normpath(sys.argv[1])
+target_file = os.path.normpath(sys.argv[2])
+
+# Check, if source file exists
+if not Path(source_file).exists():
+    print(f"Error: Source file '{source_file}' does not exist.")
+    sys.exit(1)
+
+# Check, if target file exists
+if Path(target_file).exists():
+    print(f"Error: Target file '{target_file}' does already exist.")
+    sys.exit(1)
+
+# Create a temporary working directory.
+tmp_dir = tempfile.mkdtemp()
+
+# Unpack the mrpack
+with zipfile.ZipFile(source_file, 'r') as zip_ref:
+    zip_ref.extractall(tmp_dir)
+
+# Load modrinth.index.json
+index_file_path = Path(tmp_dir) / "modrinth.index.json"
+if not index_file_path.exists():
+    print("Error: modrinth.index.json not found in the archive.")
+    sys.exit(1)
+
+with open(index_file_path, "r") as f:
+    index_data = json.load(f)
+
+# Change all 'env.client' settings to 'required'
+if "files" in index_data:
+    for file_entry in index_data["files"]:
+        if "env" in file_entry and "client" in file_entry["env"]:
+            file_entry["env"]["client"] = "required"
+
+# Save the modified JSON back
+with open(index_file_path, "w") as f:
+    json.dump(index_data, f, indent=2)
+
+# Repack the directory into a new mrpack file
+with zipfile.ZipFile(target_file, 'w', zipfile.ZIP_DEFLATED) as zip_out:
+    for foldername, subfolders, filenames in os.walk(tmp_dir):
+        for filename in filenames:
+            file_path = os.path.join(foldername, filename)
+            # Create archive-relative path
+            archive_name = os.path.relpath(file_path, tmp_dir)
+            zip_out.write(file_path, archive_name)
+

--- a/scripts/client-env-required.py
+++ b/scripts/client-env-required.py
@@ -21,8 +21,7 @@ import zipfile
 #! This is currently necessary for the Modrinth app to also include server only mods on local
 #! installs.
 #!
-#! Unpacks the `<source_file>` in a local `tmp` directory. The `tmp` directory will be automatically
-#! removed with the next restart (on Linux).
+#! Unpacks the `<source_file>` in a local `tmp` directory.
 #!
 #! # References
 #! - https://github.com/scyfar/scydventure/discussions/25#discussion-8087151
@@ -77,8 +76,8 @@ try:
             for filename in filenames:
                 file_path = os.path.join(foldername, filename)
                 # Create archive-relative path
-                arcname = os.path.relpath(file_path, tmp_dir)
-                zip_out.write(file_path, arcname)
+                archive_name = os.path.relpath(file_path, tmp_dir)
+                zip_out.write(file_path, archive_name)
 
     print(f"Repacked mrpack created at: {target_file}")
 


### PR DESCRIPTION
This is required for local use since otherwise the mods configured to only work on the server side won't be installed.

While this is correct for a distribution with a dedicated server, it causes issues when running it locally where server and client are combined.

Closes: #58